### PR TITLE
Fix:  JitPack is broken

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,3 @@
-jdk:
-  - openjdk17
+before_install:
+  - sdk install java 17.0.3.6.1-amzn
+  - sdk use java 17.0.3.6.1-amzn


### PR DESCRIPTION
Fix #1 

Use `before_install` to force initialization of the JDK.